### PR TITLE
updated sell form to include option for local delivery

### DIFF
--- a/src/components/sell/SellForm.js
+++ b/src/components/sell/SellForm.js
@@ -4,6 +4,7 @@ import ProductTypeListOptions from "./ProductTypeListOptions"
 
 const SellProductForm = (props) => {
   const [productTypes, setProductTypes] = useState([])
+  const [localDelivery, setLocalDelivery] = useState(false)
   const [newProduct, setNewProduct] = useState({
     title: "",
     price: "",
@@ -13,6 +14,11 @@ const SellProductForm = (props) => {
     location: "",
     image: "#"
   });
+
+  const updateDelivery = () => {
+    const delivery = localDelivery
+    setLocalDelivery(!delivery)
+  }
 
   const handleFieldChange = (evt) => {
     const stateToChange = { ...newProduct };
@@ -99,30 +105,37 @@ const SellProductForm = (props) => {
           />
         </fieldset>
         <fieldset>
-          <label>Location</label>
-          <input
-            type="text"
-            id="location"
-            className="form-control"
-            placeholder="Product Location"
-            onChange={handleFieldChange}
-            required
-          />
+          <label>Local Delivery?</label>
+          <input type="checkbox" onClick={updateDelivery} />
+          {localDelivery ? 
+          <div>
+            <label>Location</label>
+            <input
+              type="text"
+              id="location"
+              className="form-control"
+              placeholder="Product Location"
+              onChange={handleFieldChange}
+              required
+            />
+          </div>
+        : null}
         </fieldset>
+          
         <fieldset>
-                    <label>Product Type</label>
-                    <select className="custom-select" id="inputGroupSelect01" onChange={handleFocusSelect}>
-                        <option value="0" >Please select</option>
-                        {productTypes.length > 0 && productTypes.map((listObject) => {
-                            return <ProductTypeListOptions
-                            key={listObject.id}
-                            value={listObject.id}
-                            listObject={listObject}
-                            {...props}
-                            />
-                        })}
-                    </select>
-                </fieldset>
+          <label>Product Type</label>
+          <select className="custom-select" id="inputGroupSelect01" onChange={handleFocusSelect}>
+              <option value="0" >Please select</option>
+              {productTypes.length > 0 && productTypes.map((listObject) => {
+                  return <ProductTypeListOptions
+                  key={listObject.id}
+                  value={listObject.id}
+                  listObject={listObject}
+                  {...props}
+                  />
+              })}
+          </select>
+          </fieldset>
         <fieldset>
           <button type="button" onClick={handleSubmit}>
             Sell


### PR DESCRIPTION
_Goal of Ticket_

1. User/seller should have the option to specify local delivery available when selling a product. 
2. When they do select local delivery they have a new input to add a location for the product.

_Changes Made_

1. Added new state in SellForm.js to handle the toggle for Local Delivery option
2. Added new function in SellForm.js to update `localDelivery` state on checkbox click
3. Added checkbox in SellForm.js that triggers the function to update state

_Test_

1. When you navigate to 'sell' page, should see a checkbox with 'Local Delivery' option where the location input used to be
2. When you select that checkbox for local delivery, should see a new input render to add a location
3. Double check and make sure that you can both A) create a new item for sale without a location (I updated the constraint in the Product model in the API to null = true), and B) create a product with a location for local delivery